### PR TITLE
Enhancement: Linking next / previous model + sorting models

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -55,4 +55,7 @@ In each model YAML file, some properties can be set to customize behaviour. Othe
 ** You may specify what template this model should use to help generate it. For example, if you have the template "car&#95;temp.html" then you can set this to "car&#95;temp". Do not include ".html". By default, this is set to "template"
 
 h2. Update History: (most recent first)
+* 01-June-2014 Jens Krause (sectore) -- Jekyll 2 support
+* 23-Jan-2013 Jens Krause (sectore) -- sorting models by a key
+* 13-Jan-2013 Jens Krause (sectore) -- adding linked models
 * 20-Jun-2012 kyle paulsen -- First public release. 

--- a/jekyll_models.rb
+++ b/jekyll_models.rb
@@ -81,6 +81,14 @@
 #                          then you can set this to "car_temp". Do not include ".html".
 #                          By default, this is set to "template"
 #
+# previous:                Link to the previous model within a model list.
+#                          For example: A model list "car" has two models "audi" and "chevrolet".
+#                          "chevrolet.previous" is linked to model "audi", "audi.previous" is nil
+#
+# next:                    Link to the next model within a model list
+#                          For example: A model list "car" has two models "audi" and "chevrolet".
+#                          "audi.next" is linked to model "chevrolet", "chevrolet.next" is nil
+#
 # Update History: (most recent first)
 # 20-Jun-2012 kyle paulsen -- First public release.
 #------------------------------------------------------------------------
@@ -154,10 +162,13 @@ module JekyllModels
               "#{new_mdl["mdl_type"]}/#{new_mdl["mdl_name"]}"
             end
           end
-          
           models << new_mdl
         end
       end
+
+      # link next / previous model
+      self.link_next_previous(models)
+
       return models
     end
     
@@ -168,6 +179,19 @@ module JekyllModels
         ['.', '_', '#'].include?(e[0..0]) ||
         e[-1..-1] == '~' ||
         File.symlink?(e)
+      end
+    end
+
+    def link_next_previous(models)
+      models.each_with_index do |model, index|
+        # link to previous model
+        if index > 0
+          model['previous'] = models[index - 1]
+        end
+        # link to next model
+        if index < models.length-1
+          model['next'] = models[index+1]
+        end
       end
     end
     

--- a/jekyll_models.rb
+++ b/jekyll_models.rb
@@ -97,10 +97,13 @@
 #                          "audi.next" is linked to model "chevrolet", "chevrolet.next" is nil
 #
 # Update History: (most recent first)
+# 01-June-2014 jens krause -- Jekyll 2 support
 # 23-Jan-2013 jens krause -- sorting models by a key
 # 13-Jan-2013 jens krause -- adding linked models
 # 20-Jun-2012 kyle paulsen -- First public release.
 #------------------------------------------------------------------------
+
+require 'jekyll/utils'
 
 module JekyllModels
 
@@ -262,9 +265,10 @@ module JekyllModels
 
     # Override to set url properly
     def to_liquid
-      self.data.deep_merge({
-                               "url"        => @dest_url,
-                               "content"    => self.content })
+      self.data = Jekyll::Utils.deep_merge_hashes({
+        "url"        => @dest_url,
+        "content"    => self.content
+      }, self.data)
     end
 
     # Override so that we can control where the destination file goes


### PR DESCRIPTION
To link from one model to another within a template ("pagination") it might be helpful to have linked models using `model.next` and `model.previous`.

Example:

```
<nav>
  <ul>
    {% if page.model.previous %}
    <li><a href="{{page.model.previous.mdl_url}}">PREVIOUS</a></li>
    {% else %}
    <li>&nbsp;</li>
    {% endif %}
    {% if page.model.next %}
    <li><a href="{{page.model.next.mdl_url}}">NEXT</a></li>
    {% else %}
    <li>&nbsp;</li>
    {% endif %}
  </ul>
</nav>
```
